### PR TITLE
Using os.killpg to get threads to terminate in underlying application

### DIFF
--- a/apigen/apigen.py
+++ b/apigen/apigen.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 import json
 import sys
 import signal
+import os
 import argparse
 import inspect
 import pyjsonrpc
@@ -74,7 +75,7 @@ class Definition(object):
             )
             def sigint_handler(signum, frame):
                 #http_server.shutdown() # FIXME why does it block?
-                sys.exit(0)
+                os.killpg(os.getpgid(0), signal.SIGTERM)
             signal.signal(signal.SIGINT, sigint_handler)
             http_server.serve_forever()
 


### PR DESCRIPTION
Hi!
When pressing Ctrl-c on the keyboard:

os.killpg sending SIGTERM to entire process group, works for terminating the server after having used startserver  in the chromawallet develop branch, while sys.exit(0) does not. 

This is due to that the chromawallet application that is running under apigen is spawning its own threads.
